### PR TITLE
Fixed incorrect environment key for SteamAppId

### DIFF
--- a/game-toweroffantasy-chinese/index.js
+++ b/game-toweroffantasy-chinese/index.js
@@ -23,7 +23,7 @@ function main(context) {
       requiredFiles: ['Hotta/Binaries/Win64/QRSL.exe'],
       setup: prepareForModding,
       environment: {
-        SteamAPPId: STEAMAPP_ID,
+        SteamAppId: STEAMAPP_ID,
       },
       details: {
         steamAppId: STEAMAPP_ID

--- a/game-toweroffantasy-global/index.js
+++ b/game-toweroffantasy-global/index.js
@@ -23,7 +23,7 @@ function main(context) {
       requiredFiles: ['Hotta/Binaries/Win64/QRSL.exe'],
       setup: prepareForModding,
       environment: {
-        SteamAPPId: STEAMAPP_ID,
+        SteamAppId: STEAMAPP_ID,
       },
       details: {
         steamAppId: STEAMAPP_ID

--- a/game-toweroffantasy-korean/index.js
+++ b/game-toweroffantasy-korean/index.js
@@ -23,7 +23,7 @@ function main(context) {
       requiredFiles: ['Hotta/Binaries/Win64/QRSL.exe'],
       setup: prepareForModding,
       environment: {
-        SteamAPPId: STEAMAPP_ID,
+        SteamAppId: STEAMAPP_ID,
       },
       details: {
         steamAppId: STEAMAPP_ID


### PR DESCRIPTION
Steam version of the launcher can now be started from vortex launcher